### PR TITLE
Add location details to prospect management and filtering

### DIFF
--- a/client/src/components/add-prospect-form.tsx
+++ b/client/src/components/add-prospect-form.tsx
@@ -2,6 +2,7 @@ import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { insertProspectSchema, STATUSES, INTEREST_LEVELS } from "@shared/schema";
 import type { InsertProspect } from "@shared/schema";
+import { COUNTRIES, getStatesForCountry } from "@shared/locations";
 import { useMutation } from "@tanstack/react-query";
 import { apiRequest, queryClient } from "@/lib/queryClient";
 import { useToast } from "@/hooks/use-toast";
@@ -37,9 +38,15 @@ export function AddProspectForm({ onSuccess }: { onSuccess?: () => void }) {
       status: "Bookmarked",
       interestLevel: "Medium",
       salary: undefined,
+      city: "",
+      country: "",
+      state: "",
       notes: "",
     },
   });
+
+  const selectedCountry = form.watch("country");
+  const states = selectedCountry ? getStatesForCountry(selectedCountry) : [];
 
   const mutation = useMutation({
     mutationFn: async (data: InsertProspect) => {
@@ -181,6 +188,81 @@ export function AddProspectForm({ onSuccess }: { onSuccess?: () => void }) {
                   }}
                   data-testid="input-salary"
                 />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        <FormField
+          control={form.control}
+          name="country"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Country</FormLabel>
+              <Select
+                onValueChange={(val) => {
+                  field.onChange(val);
+                  form.setValue("state", "");
+                }}
+                value={field.value ?? ""}
+              >
+                <FormControl>
+                  <SelectTrigger data-testid="select-country">
+                    <SelectValue placeholder="Select country" />
+                  </SelectTrigger>
+                </FormControl>
+                <SelectContent>
+                  {COUNTRIES.map((c) => (
+                    <SelectItem key={c} value={c} data-testid={`option-country-${c}`}>
+                      {c}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        {states.length > 0 && (
+          <FormField
+            control={form.control}
+            name="state"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>State / Province (optional)</FormLabel>
+                <Select
+                  onValueChange={field.onChange}
+                  value={field.value ?? ""}
+                >
+                  <FormControl>
+                    <SelectTrigger data-testid="select-state">
+                      <SelectValue placeholder="Select state / province" />
+                    </SelectTrigger>
+                  </FormControl>
+                  <SelectContent>
+                    {states.map((s) => (
+                      <SelectItem key={s} value={s} data-testid={`option-state-${s}`}>
+                        {s}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+        )}
+
+        <FormField
+          control={form.control}
+          name="city"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>City</FormLabel>
+              <FormControl>
+                <Input placeholder="e.g. San Francisco" {...field} data-testid="input-city" />
               </FormControl>
               <FormMessage />
             </FormItem>

--- a/client/src/components/edit-prospect-form.tsx
+++ b/client/src/components/edit-prospect-form.tsx
@@ -2,6 +2,7 @@ import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { insertProspectSchema, STATUSES, INTEREST_LEVELS } from "@shared/schema";
 import type { InsertProspect, Prospect } from "@shared/schema";
+import { COUNTRIES, getStatesForCountry } from "@shared/locations";
 import { useMutation } from "@tanstack/react-query";
 import { apiRequest, queryClient } from "@/lib/queryClient";
 import { useToast } from "@/hooks/use-toast";
@@ -42,9 +43,15 @@ export function EditProspectForm({ prospect, onSuccess }: EditProspectFormProps)
       status: prospect.status as InsertProspect["status"],
       interestLevel: prospect.interestLevel as InsertProspect["interestLevel"],
       salary: prospect.salary ?? undefined,
+      city: prospect.city ?? "",
+      country: prospect.country ?? "",
+      state: prospect.state ?? "",
       notes: prospect.notes ?? "",
     },
   });
+
+  const selectedCountry = form.watch("country");
+  const states = selectedCountry ? getStatesForCountry(selectedCountry) : [];
 
   const mutation = useMutation({
     mutationFn: async (data: InsertProspect) => {
@@ -185,6 +192,81 @@ export function EditProspectForm({ prospect, onSuccess }: EditProspectFormProps)
                   }}
                   data-testid="input-edit-salary"
                 />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        <FormField
+          control={form.control}
+          name="country"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Country</FormLabel>
+              <Select
+                onValueChange={(val) => {
+                  field.onChange(val);
+                  form.setValue("state", "");
+                }}
+                value={field.value ?? ""}
+              >
+                <FormControl>
+                  <SelectTrigger data-testid="select-edit-country">
+                    <SelectValue placeholder="Select country" />
+                  </SelectTrigger>
+                </FormControl>
+                <SelectContent>
+                  {COUNTRIES.map((c) => (
+                    <SelectItem key={c} value={c} data-testid={`option-edit-country-${c}`}>
+                      {c}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        {states.length > 0 && (
+          <FormField
+            control={form.control}
+            name="state"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>State / Province (optional)</FormLabel>
+                <Select
+                  onValueChange={field.onChange}
+                  value={field.value ?? ""}
+                >
+                  <FormControl>
+                    <SelectTrigger data-testid="select-edit-state">
+                      <SelectValue placeholder="Select state / province" />
+                    </SelectTrigger>
+                  </FormControl>
+                  <SelectContent>
+                    {states.map((s) => (
+                      <SelectItem key={s} value={s} data-testid={`option-edit-state-${s}`}>
+                        {s}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+        )}
+
+        <FormField
+          control={form.control}
+          name="city"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>City</FormLabel>
+              <FormControl>
+                <Input placeholder="e.g. San Francisco" {...field} data-testid="input-edit-city" />
               </FormControl>
               <FormMessage />
             </FormItem>

--- a/client/src/components/prospect-card.tsx
+++ b/client/src/components/prospect-card.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import type { Prospect } from "@shared/schema";
 import { Button } from "@/components/ui/button";
-import { ExternalLink, Trash2, Pencil, Flame, ThumbsUp, Minus, DollarSign } from "lucide-react";
+import { ExternalLink, Trash2, Pencil, Flame, ThumbsUp, Minus, DollarSign, MapPin } from "lucide-react";
 import { useMutation } from "@tanstack/react-query";
 import { apiRequest, queryClient } from "@/lib/queryClient";
 import { useToast } from "@/hooks/use-toast";
@@ -109,6 +109,12 @@ export function ProspectCard({ prospect }: { prospect: Prospect }) {
             <span className="inline-flex items-center gap-0.5 text-xs font-medium text-emerald-600 dark:text-emerald-400" data-testid={`text-salary-${prospect.id}`}>
               <DollarSign className="w-3 h-3" />
               {prospect.salary.toLocaleString("en-US", { minimumFractionDigits: prospect.salary % 1 !== 0 ? 2 : 0, maximumFractionDigits: 2 })}
+            </span>
+          )}
+          {prospect.country && (
+            <span className="inline-flex items-center gap-0.5 text-xs font-medium text-sky-600 dark:text-sky-400" data-testid={`text-location-${prospect.id}`}>
+              <MapPin className="w-3 h-3" />
+              {[prospect.city, prospect.state, prospect.country].filter(Boolean).join(", ")}
             </span>
           )}
         </div>

--- a/client/src/pages/home.tsx
+++ b/client/src/pages/home.tsx
@@ -1,10 +1,10 @@
-import { useState } from "react";
+import { useState, useMemo } from "react";
 import { useQuery } from "@tanstack/react-query";
 import type { Prospect } from "@shared/schema";
 import { STATUSES, INTEREST_LEVELS } from "@shared/schema";
 import { ProspectCard } from "@/components/prospect-card";
 import { AddProspectForm } from "@/components/add-prospect-form";
-import { Briefcase, Plus, Filter } from "lucide-react";
+import { Briefcase, Plus, Filter, MapPin } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -45,12 +45,27 @@ function KanbanColumn({
   isLoading: boolean;
 }) {
   const [interestFilter, setInterestFilter] = useState<InterestFilter>("All");
+  const [locationFilter, setLocationFilter] = useState<string>("All");
   const statusSlug = status.replace(/\s+/g, "-").toLowerCase();
 
-  const filteredProspects =
-    interestFilter === "All"
-      ? prospects
-      : prospects.filter((p) => p.interestLevel === interestFilter);
+  const uniqueLocations = useMemo(() => {
+    const locs = new Set<string>();
+    prospects.forEach((p) => {
+      if (p.country) {
+        locs.add([p.city, p.state, p.country].filter(Boolean).join(", "));
+      }
+    });
+    return Array.from(locs).sort();
+  }, [prospects]);
+
+  const filteredProspects = prospects.filter((p) => {
+    if (interestFilter !== "All" && p.interestLevel !== interestFilter) return false;
+    if (locationFilter !== "All") {
+      const loc = [p.city, p.state, p.country].filter(Boolean).join(", ");
+      if (loc !== locationFilter) return false;
+    }
+    return true;
+  });
 
   return (
     <div
@@ -68,7 +83,7 @@ function KanbanColumn({
           {filteredProspects.length}
         </Badge>
       </div>
-      <div className="px-2 pt-2">
+      <div className="px-2 pt-2 space-y-1.5">
         <Select
           value={interestFilter}
           onValueChange={(val) => setInterestFilter(val as InterestFilter)}
@@ -95,6 +110,34 @@ function KanbanColumn({
             ))}
           </SelectContent>
         </Select>
+        {uniqueLocations.length > 0 && (
+          <Select
+            value={locationFilter}
+            onValueChange={setLocationFilter}
+          >
+            <SelectTrigger
+              className="h-7 text-xs w-full"
+              data-testid={`filter-location-${statusSlug}`}
+            >
+              <MapPin className="w-3 h-3 mr-1 shrink-0" />
+              <SelectValue placeholder="Filter by location" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="All" data-testid={`filter-location-all-${statusSlug}`}>
+                All Locations
+              </SelectItem>
+              {uniqueLocations.map((loc) => (
+                <SelectItem
+                  key={loc}
+                  value={loc}
+                  data-testid={`filter-location-option-${statusSlug}`}
+                >
+                  {loc}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        )}
       </div>
       <div className="flex-1 overflow-y-auto px-2 py-2">
         <div className="space-y-2">
@@ -106,7 +149,9 @@ function KanbanColumn({
           ) : filteredProspects.length === 0 ? (
             <div className="flex flex-col items-center justify-center py-8 text-center" data-testid={`empty-${statusSlug}`}>
               <p className="text-xs text-muted-foreground">
-                {interestFilter === "All" ? "No prospects" : `No ${interestFilter.toLowerCase()} interest prospects`}
+                {interestFilter === "All" && locationFilter === "All"
+                  ? "No prospects"
+                  : "No matching prospects"}
               </p>
             </div>
           ) : (

--- a/replit.md
+++ b/replit.md
@@ -11,7 +11,8 @@ A Kanban-style job search tracker built with React, Express, and PostgreSQL. Pro
 ## File Structure
 
 ```
-shared/schema.ts              - Database table definition, Zod validation, TypeScript types
+shared/schema.ts              - Database table definition, Zod validation (with location refinements), TypeScript types
+shared/locations.ts           - Country/state data, COUNTRIES list, getStatesForCountry(), isValidStateForCountry()
 server/
   index.ts                    - Express app bootstrap, middleware, server start
   db.ts                       - PostgreSQL connection pool (Drizzle)
@@ -30,10 +31,12 @@ client/src/
 
 ## Database
 
-Single `prospects` table: id, company_name, role_title, job_url, status, interest_level, notes, created_at.
+Single `prospects` table: id, company_name, role_title, job_url, status, interest_level, salary, city, state, country, notes, created_at.
 
 - **Statuses**: Bookmarked, Applied, Phone Screen, Interviewing, Offer, Rejected, Withdrawn
 - **Interest levels**: High, Medium, Low
+- **Location**: city (required), country (required, validated against known list), state (optional, validated against country)
+- **Location data**: `shared/locations.ts` — country list with states/provinces, helper functions
 
 ## API
 

--- a/server/__tests__/prospect-validation.test.ts
+++ b/server/__tests__/prospect-validation.test.ts
@@ -1,11 +1,18 @@
 import { validateProspect } from "../prospect-helpers";
 
+const validBase = {
+  companyName: "Google",
+  roleTitle: "Software Engineer",
+  salary: 80000,
+  city: "San Francisco",
+  country: "United States",
+};
+
 describe("prospect creation validation", () => {
   test("rejects a blank company name", () => {
     const result = validateProspect({
+      ...validBase,
       companyName: "",
-      roleTitle: "Software Engineer",
-      salary: 80000,
     });
 
     expect(result.valid).toBe(false);
@@ -14,9 +21,8 @@ describe("prospect creation validation", () => {
 
   test("rejects a blank role title", () => {
     const result = validateProspect({
-      companyName: "Google",
+      ...validBase,
       roleTitle: "",
-      salary: 80000,
     });
 
     expect(result.valid).toBe(false);
@@ -25,8 +31,7 @@ describe("prospect creation validation", () => {
 
   test("accepts a valid prospect with all required fields", () => {
     const result = validateProspect({
-      companyName: "Google",
-      roleTitle: "Software Engineer",
+      ...validBase,
       salary: 120000,
     });
 
@@ -40,6 +45,8 @@ describe("salary validation", () => {
     const result = validateProspect({
       companyName: "Google",
       roleTitle: "Software Engineer",
+      city: "NYC",
+      country: "United States",
     });
 
     expect(result.valid).toBe(false);
@@ -48,8 +55,7 @@ describe("salary validation", () => {
 
   test("rejects null salary", () => {
     const result = validateProspect({
-      companyName: "Google",
-      roleTitle: "Software Engineer",
+      ...validBase,
       salary: null,
     });
 
@@ -59,8 +65,7 @@ describe("salary validation", () => {
 
   test("rejects negative salary", () => {
     const result = validateProspect({
-      companyName: "Google",
-      roleTitle: "Software Engineer",
+      ...validBase,
       salary: -50000,
     });
 
@@ -70,8 +75,7 @@ describe("salary validation", () => {
 
   test("rejects non-numeric salary", () => {
     const result = validateProspect({
-      companyName: "Google",
-      roleTitle: "Software Engineer",
+      ...validBase,
       salary: "eighty thousand",
     });
 
@@ -81,8 +85,7 @@ describe("salary validation", () => {
 
   test("rejects NaN salary", () => {
     const result = validateProspect({
-      companyName: "Google",
-      roleTitle: "Software Engineer",
+      ...validBase,
       salary: NaN,
     });
 
@@ -92,8 +95,7 @@ describe("salary validation", () => {
 
   test("accepts zero salary", () => {
     const result = validateProspect({
-      companyName: "Google",
-      roleTitle: "Software Engineer",
+      ...validBase,
       salary: 0,
     });
 
@@ -103,8 +105,7 @@ describe("salary validation", () => {
 
   test("accepts whole number salary", () => {
     const result = validateProspect({
-      companyName: "Google",
-      roleTitle: "Software Engineer",
+      ...validBase,
       salary: 85000,
     });
 
@@ -114,8 +115,7 @@ describe("salary validation", () => {
 
   test("accepts salary with decimals", () => {
     const result = validateProspect({
-      companyName: "Google",
-      roleTitle: "Software Engineer",
+      ...validBase,
       salary: 85000.50,
     });
 
@@ -125,12 +125,167 @@ describe("salary validation", () => {
 
   test("accepts large salary values", () => {
     const result = validateProspect({
-      companyName: "Google",
+      ...validBase,
       roleTitle: "CEO",
       salary: 500000,
     });
 
     expect(result.valid).toBe(true);
     expect(result.errors).toHaveLength(0);
+  });
+});
+
+describe("location validation", () => {
+  test("rejects missing city", () => {
+    const result = validateProspect({
+      companyName: "Google",
+      roleTitle: "Software Engineer",
+      salary: 120000,
+      country: "United States",
+    });
+
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain("City is required");
+  });
+
+  test("rejects empty city", () => {
+    const result = validateProspect({
+      ...validBase,
+      city: "",
+    });
+
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain("City is required");
+  });
+
+  test("rejects blank city (whitespace only)", () => {
+    const result = validateProspect({
+      ...validBase,
+      city: "   ",
+    });
+
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain("City is required");
+  });
+
+  test("rejects missing country", () => {
+    const result = validateProspect({
+      companyName: "Google",
+      roleTitle: "Software Engineer",
+      salary: 120000,
+      city: "San Francisco",
+    });
+
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain("Country is required");
+  });
+
+  test("rejects empty country", () => {
+    const result = validateProspect({
+      ...validBase,
+      country: "",
+    });
+
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain("Country is required");
+  });
+
+  test("rejects invalid country", () => {
+    const result = validateProspect({
+      ...validBase,
+      country: "Narnia",
+    });
+
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain("Invalid country");
+  });
+
+  test("accepts valid US state for United States", () => {
+    const result = validateProspect({
+      ...validBase,
+      state: "California",
+    });
+
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  test("rejects invalid state for United States", () => {
+    const result = validateProspect({
+      ...validBase,
+      state: "Ontario",
+    });
+
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain("Invalid state for selected country");
+  });
+
+  test("accepts valid Canadian province for Canada", () => {
+    const result = validateProspect({
+      ...validBase,
+      country: "Canada",
+      city: "Toronto",
+      state: "Ontario",
+    });
+
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  test("rejects US state for Canada", () => {
+    const result = validateProspect({
+      ...validBase,
+      country: "Canada",
+      city: "Toronto",
+      state: "California",
+    });
+
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain("Invalid state for selected country");
+  });
+
+  test("accepts country with no states and any state value", () => {
+    const result = validateProspect({
+      ...validBase,
+      country: "Singapore",
+      city: "Singapore",
+      state: "Anything",
+    });
+
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  test("accepts prospect with no state (state is optional)", () => {
+    const result = validateProspect({
+      ...validBase,
+    });
+
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  test("accepts valid UK region for United Kingdom", () => {
+    const result = validateProspect({
+      ...validBase,
+      country: "United Kingdom",
+      city: "London",
+      state: "England",
+    });
+
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  test("rejects invalid region for United Kingdom", () => {
+    const result = validateProspect({
+      ...validBase,
+      country: "United Kingdom",
+      city: "London",
+      state: "California",
+    });
+
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain("Invalid state for selected country");
   });
 });

--- a/server/prospect-helpers.ts
+++ b/server/prospect-helpers.ts
@@ -1,4 +1,5 @@
 import { STATUSES, INTEREST_LEVELS } from "@shared/schema";
+import { COUNTRIES, getStatesForCountry, isValidStateForCountry } from "@shared/locations";
 
 export function getNextStatus(currentStatus: string): string {
   const terminalStatuses = ["Offer", "Rejected", "Withdrawn"];
@@ -45,6 +46,23 @@ export function validateProspect(data: Record<string, unknown>): { valid: boolea
     errors.push("Salary must be a valid number");
   } else if (data.salary < 0) {
     errors.push("Salary must be a positive number");
+  }
+
+  if (!data.city || typeof data.city !== "string" || data.city.trim() === "") {
+    errors.push("City is required");
+  }
+
+  if (!data.country || typeof data.country !== "string" || data.country.trim() === "") {
+    errors.push("Country is required");
+  } else if (!COUNTRIES.includes(data.country as string)) {
+    errors.push("Invalid country");
+  } else {
+    const states = getStatesForCountry(data.country as string);
+    if (data.state && typeof data.state === "string" && data.state.trim() !== "") {
+      if (states.length > 0 && !isValidStateForCountry(data.state as string, data.country as string)) {
+        errors.push("Invalid state for selected country");
+      }
+    }
   }
 
   return { valid: errors.length === 0, errors };

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -39,7 +39,33 @@ export async function registerRoutes(
     if (body.roleTitle !== undefined) updates.roleTitle = body.roleTitle;
     if (body.jobUrl !== undefined) updates.jobUrl = body.jobUrl;
     if (body.salary !== undefined) updates.salary = body.salary;
+    if (body.city !== undefined) updates.city = body.city;
+    if (body.state !== undefined) updates.state = body.state;
+    if (body.country !== undefined) updates.country = body.country;
     if (body.notes !== undefined) updates.notes = body.notes;
+
+    if (updates.country !== undefined || updates.state !== undefined || updates.city !== undefined) {
+      const { COUNTRIES, getStatesForCountry } = await import("@shared/locations");
+      const finalCountry = (updates.country ?? existing.country) as string | null;
+      const finalCity = (updates.city ?? existing.city) as string | null;
+      const finalState = (updates.state ?? existing.state) as string | null;
+
+      if (!finalCity || finalCity.trim() === "") {
+        return res.status(400).json({ message: "City is required" });
+      }
+      if (!finalCountry || finalCountry.trim() === "") {
+        return res.status(400).json({ message: "Country is required" });
+      }
+      if (!COUNTRIES.includes(finalCountry)) {
+        return res.status(400).json({ message: "Invalid country" });
+      }
+      if (finalState && finalState.trim() !== "") {
+        const states = getStatesForCountry(finalCountry);
+        if (states.length > 0 && !states.includes(finalState)) {
+          return res.status(400).json({ message: "Invalid state for selected country" });
+        }
+      }
+    }
 
     if (body.status !== undefined) {
       if (!STATUSES.includes(body.status)) {

--- a/shared/locations.ts
+++ b/shared/locations.ts
@@ -1,0 +1,125 @@
+export const COUNTRIES_WITH_STATES: Record<string, string[]> = {
+  "United States": [
+    "Alabama", "Alaska", "Arizona", "Arkansas", "California", "Colorado",
+    "Connecticut", "Delaware", "Florida", "Georgia", "Hawaii", "Idaho",
+    "Illinois", "Indiana", "Iowa", "Kansas", "Kentucky", "Louisiana",
+    "Maine", "Maryland", "Massachusetts", "Michigan", "Minnesota",
+    "Mississippi", "Missouri", "Montana", "Nebraska", "Nevada",
+    "New Hampshire", "New Jersey", "New Mexico", "New York",
+    "North Carolina", "North Dakota", "Ohio", "Oklahoma", "Oregon",
+    "Pennsylvania", "Rhode Island", "South Carolina", "South Dakota",
+    "Tennessee", "Texas", "Utah", "Vermont", "Virginia", "Washington",
+    "West Virginia", "Wisconsin", "Wyoming", "District of Columbia",
+  ],
+  "Canada": [
+    "Alberta", "British Columbia", "Manitoba", "New Brunswick",
+    "Newfoundland and Labrador", "Northwest Territories", "Nova Scotia",
+    "Nunavut", "Ontario", "Prince Edward Island", "Quebec", "Saskatchewan",
+    "Yukon",
+  ],
+  "United Kingdom": [
+    "England", "Scotland", "Wales", "Northern Ireland",
+  ],
+  "Australia": [
+    "Australian Capital Territory", "New South Wales", "Northern Territory",
+    "Queensland", "South Australia", "Tasmania", "Victoria", "Western Australia",
+  ],
+  "Germany": [
+    "Baden-Württemberg", "Bavaria", "Berlin", "Brandenburg", "Bremen",
+    "Hamburg", "Hesse", "Lower Saxony", "Mecklenburg-Vorpommern",
+    "North Rhine-Westphalia", "Rhineland-Palatinate", "Saarland",
+    "Saxony", "Saxony-Anhalt", "Schleswig-Holstein", "Thuringia",
+  ],
+  "India": [
+    "Andhra Pradesh", "Arunachal Pradesh", "Assam", "Bihar", "Chhattisgarh",
+    "Goa", "Gujarat", "Haryana", "Himachal Pradesh", "Jharkhand", "Karnataka",
+    "Kerala", "Madhya Pradesh", "Maharashtra", "Manipur", "Meghalaya",
+    "Mizoram", "Nagaland", "Odisha", "Punjab", "Rajasthan", "Sikkim",
+    "Tamil Nadu", "Telangana", "Tripura", "Uttar Pradesh", "Uttarakhand",
+    "West Bengal",
+  ],
+  "Brazil": [
+    "Acre", "Alagoas", "Amapá", "Amazonas", "Bahia", "Ceará",
+    "Distrito Federal", "Espírito Santo", "Goiás", "Maranhão",
+    "Mato Grosso", "Mato Grosso do Sul", "Minas Gerais", "Pará",
+    "Paraíba", "Paraná", "Pernambuco", "Piauí", "Rio de Janeiro",
+    "Rio Grande do Norte", "Rio Grande do Sul", "Rondônia", "Roraima",
+    "Santa Catarina", "São Paulo", "Sergipe", "Tocantins",
+  ],
+  "Mexico": [
+    "Aguascalientes", "Baja California", "Baja California Sur", "Campeche",
+    "Chiapas", "Chihuahua", "Ciudad de México", "Coahuila", "Colima",
+    "Durango", "Guanajuato", "Guerrero", "Hidalgo", "Jalisco",
+    "Estado de México", "Michoacán", "Morelos", "Nayarit", "Nuevo León",
+    "Oaxaca", "Puebla", "Querétaro", "Quintana Roo", "San Luis Potosí",
+    "Sinaloa", "Sonora", "Tabasco", "Tamaulipas", "Tlaxcala", "Veracruz",
+    "Yucatán", "Zacatecas",
+  ],
+  "Japan": [
+    "Hokkaido", "Aomori", "Iwate", "Miyagi", "Akita", "Yamagata",
+    "Fukushima", "Ibaraki", "Tochigi", "Gunma", "Saitama", "Chiba",
+    "Tokyo", "Kanagawa", "Niigata", "Toyama", "Ishikawa", "Fukui",
+    "Yamanashi", "Nagano", "Gifu", "Shizuoka", "Aichi", "Mie", "Shiga",
+    "Kyoto", "Osaka", "Hyogo", "Nara", "Wakayama", "Tottori", "Shimane",
+    "Okayama", "Hiroshima", "Yamaguchi", "Tokushima", "Kagawa", "Ehime",
+    "Kochi", "Fukuoka", "Saga", "Nagasaki", "Kumamoto", "Oita", "Miyazaki",
+    "Kagoshima", "Okinawa",
+  ],
+  "France": [
+    "Auvergne-Rhône-Alpes", "Bourgogne-Franche-Comté", "Brittany",
+    "Centre-Val de Loire", "Corsica", "Grand Est", "Hauts-de-France",
+    "Île-de-France", "Normandy", "Nouvelle-Aquitaine", "Occitanie",
+    "Pays de la Loire", "Provence-Alpes-Côte d'Azur",
+  ],
+  "Italy": [
+    "Abruzzo", "Basilicata", "Calabria", "Campania", "Emilia-Romagna",
+    "Friuli Venezia Giulia", "Lazio", "Liguria", "Lombardy", "Marche",
+    "Molise", "Piedmont", "Puglia", "Sardinia", "Sicily", "Trentino-South Tyrol",
+    "Tuscany", "Umbria", "Aosta Valley", "Veneto",
+  ],
+  "South Korea": [
+    "Seoul", "Busan", "Daegu", "Incheon", "Gwangju", "Daejeon", "Ulsan",
+    "Sejong", "Gyeonggi", "Gangwon", "North Chungcheong", "South Chungcheong",
+    "North Jeolla", "South Jeolla", "North Gyeongsang", "South Gyeongsang", "Jeju",
+  ],
+  "China": [
+    "Anhui", "Beijing", "Chongqing", "Fujian", "Gansu", "Guangdong",
+    "Guangxi", "Guizhou", "Hainan", "Hebei", "Heilongjiang", "Henan",
+    "Hubei", "Hunan", "Inner Mongolia", "Jiangsu", "Jiangxi", "Jilin",
+    "Liaoning", "Ningxia", "Qinghai", "Shaanxi", "Shandong", "Shanghai",
+    "Shanxi", "Sichuan", "Tianjin", "Tibet", "Xinjiang", "Yunnan", "Zhejiang",
+  ],
+  "Spain": [
+    "Andalusia", "Aragon", "Asturias", "Balearic Islands", "Basque Country",
+    "Canary Islands", "Cantabria", "Castile and León", "Castilla-La Mancha",
+    "Catalonia", "Extremadura", "Galicia", "La Rioja", "Community of Madrid",
+    "Region of Murcia", "Navarre", "Valencian Community",
+  ],
+  "Netherlands": [],
+  "Sweden": [],
+  "Switzerland": [],
+  "Singapore": [],
+  "Ireland": [],
+  "Israel": [],
+  "New Zealand": [],
+  "South Africa": [],
+  "United Arab Emirates": [],
+  "Poland": [],
+  "Argentina": [],
+  "Colombia": [],
+  "Philippines": [],
+  "Nigeria": [],
+  "Remote": [],
+};
+
+export const COUNTRIES = Object.keys(COUNTRIES_WITH_STATES).sort();
+
+export function getStatesForCountry(country: string): string[] {
+  return COUNTRIES_WITH_STATES[country] || [];
+}
+
+export function isValidStateForCountry(state: string, country: string): boolean {
+  const states = getStatesForCountry(country);
+  if (states.length === 0) return true;
+  return states.includes(state);
+}

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -1,6 +1,7 @@
 import { pgTable, serial, text, timestamp, doublePrecision } from "drizzle-orm/pg-core";
 import { createInsertSchema } from "drizzle-zod";
 import { z } from "zod";
+import { COUNTRIES, getStatesForCountry } from "./locations";
 
 export const STATUSES = [
   "Bookmarked",
@@ -22,6 +23,9 @@ export const prospects = pgTable("prospects", {
   status: text("status").notNull().default("Bookmarked"),
   interestLevel: text("interest_level").notNull().default("Medium"),
   salary: doublePrecision("salary"),
+  city: text("city"),
+  state: text("state"),
+  country: text("country"),
   notes: text("notes"),
   createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
 });
@@ -35,9 +39,23 @@ export const insertProspectSchema = createInsertSchema(prospects).omit({
   status: z.enum(STATUSES).default("Bookmarked"),
   interestLevel: z.enum(INTEREST_LEVELS).default("Medium"),
   salary: z.number({ required_error: "Salary is required. If unknown, make your best guess." }).min(0, "Salary must be a positive number"),
+  city: z.string().min(1, "City is required"),
+  country: z.string().min(1, "Country is required").refine(
+    (val) => COUNTRIES.includes(val),
+    { message: "Invalid country" }
+  ),
+  state: z.string().optional().nullable(),
   jobUrl: z.string().optional().nullable(),
   notes: z.string().optional().nullable(),
-});
+}).refine(
+  (data) => {
+    if (!data.state || !data.country) return true;
+    const states = getStatesForCountry(data.country);
+    if (states.length === 0) return true;
+    return states.includes(data.state);
+  },
+  { message: "Invalid state for selected country", path: ["state"] }
+);
 
 export type InsertProspect = z.infer<typeof insertProspectSchema>;
 export type Prospect = typeof prospects.$inferSelect;


### PR DESCRIPTION
Adds city, state, and country fields to the prospect model, enabling location-based filtering on the Kanban board and improving prospect data accuracy with validation.

Replit-Commit-Author: Agent
Replit-Commit-Session-Id: 13f14f62-7232-418f-8a0a-47919757f31c
Replit-Commit-Checkpoint-Type: full_checkpoint
Replit-Commit-Event-Id: def7329a-7cc1-4655-98d5-df9da10a750c
Replit-Commit-Screenshot-Url: https://storage.googleapis.com/screenshot-production-us-central1/e20d57d2-e8cb-41df-9f9f-b0b5fcc7cda4/13f14f62-7232-418f-8a0a-47919757f31c/STagBQQ
Replit-Helium-Checkpoint-Created: true